### PR TITLE
Fix compile errors with new Vala

### DIFF
--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -25,18 +25,18 @@ public interface BluetoothIndicator.Services.Device : Object {
     public abstract void pair () throws Error;
 
     public abstract string[] UUIDs { owned get; }
-    public abstract bool blocked { owned get; set; }
-    public abstract bool connected { owned get; }
-    public abstract bool legacy_pairing { owned get; }
-    public abstract bool paired { owned get; }
-    public abstract bool trusted { owned get; set; }
-    public abstract int16 RSSI { owned get; }
+    public abstract bool blocked { get; set; }
+    public abstract bool connected { get; }
+    public abstract bool legacy_pairing { get; }
+    public abstract bool paired { get; }
+    public abstract bool trusted { get; set; }
+    public abstract int16 RSSI { get; }
     public abstract ObjectPath adapter { owned get; }
     public abstract string address { owned get; }
     public abstract string alias { owned get; set; }
     public abstract string icon { owned get; }
     public abstract string modalias { owned get; }
     public abstract string name { owned get; }
-    public abstract uint16 appearance { owned get; }
-    public abstract uint32 @class { owned get; }
+    public abstract uint16 appearance { get; }
+    public abstract uint32 @class { get; }
 }

--- a/src/Services/Session.vala
+++ b/src/Services/Session.vala
@@ -20,7 +20,7 @@ public interface BluetoothIndicator.Services.Obex.Session : Object {
     public abstract string get_capabilities () throws GLib.Error;
     public abstract string source { owned get; }
     public abstract string destination { owned get; }
-    public abstract uchar channel { owned get; }
+    public abstract uchar channel { get; }
     public abstract string target { owned get; }
     public abstract string root { owned get; }
 }

--- a/src/Services/Transfer.vala
+++ b/src/Services/Transfer.vala
@@ -22,8 +22,8 @@ public interface BluetoothIndicator.Services.Obex.Transfer : Object {
     public abstract ObjectPath session { owned get; }
     public abstract string name { owned get; }
     public abstract string Type { owned get; }
-    public abstract uint64 time { owned get; }
-    public abstract uint64 size { owned get; }
-    public abstract uint64 transferred { owned get; }
+    public abstract uint64 time { get; }
+    public abstract uint64 size { get; }
+    public abstract uint64 transferred { get; }
     public abstract string filename { owned get; }
 }


### PR DESCRIPTION
```
../src/Services/Device.vala:28:36-28:45: error: `owned' accessor not allowed for specified property type
   28 |     public abstract bool blocked { owned get; set; }
      |                                    ^~~~~~~~~~       
../src/Services/Device.vala:29:38-29:47: error: `owned' accessor not allowed for specified property type
   29 |     public abstract bool connected { owned get; }
      |                                      ^~~~~~~~~~  
../src/Services/Device.vala:30:43-30:52: error: `owned' accessor not allowed for specified property type
   30 |     public abstract bool legacy_pairing { owned get; }
      |                                           ^~~~~~~~~~  
../src/Services/Device.vala:31:35-31:44: error: `owned' accessor not allowed for specified property type
   31 |     public abstract bool paired { owned get; }
      |                                   ^~~~~~~~~~  
../src/Services/Device.vala:32:36-32:45: error: `owned' accessor not allowed for specified property type
   32 |     public abstract bool trusted { owned get; set; }
      |                                    ^~~~~~~~~~       
../src/Services/Device.vala:33:34-33:43: error: `owned' accessor not allowed for specified property type
   33 |     public abstract int16 RSSI { owned get; }
      |                                  ^~~~~~~~~~  
../src/Services/Device.vala:40:41-40:50: error: `owned' accessor not allowed for specified property type
   40 |     public abstract uint16 appearance { owned get; }
      |                                         ^~~~~~~~~~  
../src/Services/Device.vala:41:37-41:46: error: `owned' accessor not allowed for specified property type
   41 |     public abstract uint32 @class { owned get; }
      |                                     ^~~~~~~~~~  
../src/Services/Transfer.vala:25:35-25:44: error: `owned' accessor not allowed for specified property type
   25 |     public abstract uint64 time { owned get; }
      |                                   ^~~~~~~~~~  
../src/Services/Transfer.vala:26:35-26:44: error: `owned' accessor not allowed for specified property type
   26 |     public abstract uint64 size { owned get; }
      |                                   ^~~~~~~~~~  
../src/Services/Transfer.vala:27:42-27:51: error: `owned' accessor not allowed for specified property type
   27 |     public abstract uint64 transferred { owned get; }
      |                                          ^~~~~~~~~~  
../src/Services/Session.vala:23:37-23:46: error: `owned' accessor not allowed for specified property type
   23 |     public abstract uchar channel { owned get; }
      |                                     ^~~~~~~~~~  
Compilation failed: 12 error(s), 2 warning(s)
```